### PR TITLE
Bump Python to >= 3.7

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         sphinx-version:
           - '4.0.3'
           - '4.1.2'
@@ -19,10 +19,6 @@ jobs:
           - '5.3.0'
           - git+https://github.com/sphinx-doc/sphinx.git@master
         exclude:
-          # Since sphinx 7e68154e49fbb260f7ffee9791bfafdb7fd2e119 python 3.6
-          # support is removed. Breathe will probably also drop 3.6 soon.
-          - python-version: '3.6'
-            sphinx-version: git+https://github.com/sphinx-doc/sphinx.git@master
           # avoid bug in following configurations
           # sphinx/util/typing.py:37: in <module>
           #     from types import Union as types_Union

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,6 +27,9 @@ jobs:
             sphinx-version: '4.0.3'
           - python-version: '3.10'
             sphinx-version: '4.1.2'
+          # Sphinx has removed support for Python 3.7, Breathe will follow.
+          - python-version: '3.7'
+            sphinx-version: git+https://github.com/sphinx-doc/sphinx.git@master
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Inspired by `Keepachangelog.com <http://keepachangelog.com/>`__.
     `#833 <https://github.com/michaeljones/breathe/pull/833>`__
   - Fix tests for changes in Sphinx 5.3.
     `#865 <https://github.com/breathe-doc/breathe/pull/865>`__
+  - Bump Python requirement to 3.7.
+    `#866 <https://github.com/breathe-doc/breathe/pull/866>`__
 
 - 2022-06-20 - **Breathe v4.34.0**
 

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ Breathe is an extension to reStructuredText and Sphinx to be able to read and
 
 requires = ["Sphinx>=4.0,<6,!=5.0.0", "docutils>=0.12"]
 
-if sys.version_info < (3, 6):
-    print("ERROR: Sphinx requires at least Python 3.6 to run.")
+if sys.version_info < (3, 7):
+    print("ERROR: Sphinx requires at least Python 3.7 to run.")
     sys.exit(1)
 
 


### PR DESCRIPTION
Python 3.6 is no longer supported. Let's drop it.