### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "Development Status :: 4 - Beta",
         "Environment :: Console",
         "Environment :: Web Environment",
+        "Framework :: Sphinx :: Extension",
         "Intended Audience :: Developers",
         "Intended Audience :: Education",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).

You may also want to add the [sphinx-extension](https://github.com/topics/sphinx-extension) repo topic, there are over 200 other extensions using it.