### PR TITLE
Fix auto doc for multiple projects

### DIFF
--- a/breathe/process.py
+++ b/breathe/process.py
@@ -64,6 +64,9 @@ class AutoDoxygenProcessHandle:
         # Iterate over the projects and generate doxygen xml output for the files for each one into
         # a directory in the Sphinx build area
         for project_name, data in project_files.items():
+            # Update the project name
+            data.auto_project_info._name = project_name
+            
             project_path = self.process(
                 data.auto_project_info, data.files, doxygen_options, doxygen_aliases
             )


### PR DESCRIPTION
When attempting to use auto doc for multiple projects, breathe would only create one Doxygen `.cfg` file and only one directory within the `breathe/doxygen` directory. Each time it would overwrite the previous contents. Finally at the end it would not be able to find any files from projects, except the last project in the `breathe_projects_source` dictionary.

This PR fixes that situation.

Example `conf.py`:

```py
breathe_projects_source = {
    "main": (
        "../../src", [
            "main.h",
        ]
    ),
    "some_project": (
        "../../src", [
            "some_file.h",
        ]
    ),
}
```

Before PR:
![image](https://user-images.githubusercontent.com/42013603/225424601-8ae8d7bb-d030-4252-84f6-cafcb3767ebd.png)

After PR:
![image](https://user-images.githubusercontent.com/42013603/225424965-0a356c32-e180-402e-9bdb-aab01a1f43ce.png)
