### PR TITLE
Fix auto doc for multiple projects (alternate)

### DIFF
--- a/breathe/project.py
+++ b/breathe/project.py
@@ -202,7 +202,7 @@ class ProjectInfoFactory:
         return self.project_info_for_auto_store[name]
 
     def create_auto_project_info(self, name: str, source_path) -> AutoProjectInfo:
-        key = source_path
+        key = name if name else source_path
         try:
             return self.auto_project_info_store[key]
         except KeyError:


### PR DESCRIPTION
This is an alternate for #896.

I was reviewing the code closer and could not determine why the name was not updating, but discovered that the directory is used as the key instead of the project name. I believe the project name should be used in order to remain consistent with the dictionary within the `conf.py`.

In my case, I had multiple projects with the same directory (which may be a misuse on my part).

I have allowed for a fallback to the `source_path` if the `name` is not available, although I couldn't think of a situation where the project name would not exist (but I am not extremely familiar with the entire project).

P.S. I started investigating using the autodoxygen method to resolve an issue I'm having, which I will create an issue for, since I still can't seem to solve it.