### PR TITLE
mkrelease: explicitly use gzip for tarball generation

### DIFF
--- a/mkrelease
+++ b/mkrelease
@@ -31,10 +31,11 @@ pack()
 	mkdir -- mkrelease_tmp
 
 	git archive \
-		--format=tar.gz \
+		--format=tar \
 		--prefix="breathe-$version/" \
-		-o "mkrelease_tmp/breathe-$version.tar.gz" \
 		-- "v$version" \
+		| gzip -cn \
+		>"mkrelease_tmp/breathe-$version.tar.gz"
 
 	cd -- mkrelease_tmp
 	tar -xf "breathe-$version.tar.gz"


### PR DESCRIPTION
Since git v2.38.0 git archive tar.gz format default has changed from invoking gzip to an internal gzip compressor implementation. However, the output bitstream is not identical, meaning the resulting tar.gz archive's checksum is different. This causes problems for PGP signing.

In order to avoid this issue for both old and new archive generation alike manually invoke gzip in mkrelease script, bypassing git archive's internal compression logic completely regardless of version.

GitHub and others presumably use a similar method to deal with this change to keep old tag archive checksums from changing.

* https://github.com/git/git/commit/4f4be00d302bc52d0d9d5a3d4738bb525066c710
* https://github.blog/changelog/2023-01-30-git-archive-checksums-may-change/
* https://github.com/orgs/community/discussions/45830
* https://github.com/bazel-contrib/SIG-rules-authors/issues/11