### PR TITLE
Fix for admonitions being displayed out of their original context.

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -886,8 +886,6 @@ class SphinxRenderer:
         detailed = []
         for candNode in detailedCand:
             pullup(candNode, nodes.field_list, fieldLists)
-            pullup(candNode, nodes.note, admonitions)
-            pullup(candNode, nodes.warning, admonitions)
             # and collapse paragraphs
             for para in candNode.traverse(nodes.paragraph):
                 if (


### PR DESCRIPTION
Removes 'pullup' for admonitions in detailed description to keep them in context.

File changed:  breathe/renderer/sphinxrenderer.py

This is a fix for #889 