### PR TITLE
Support member references for members in group (Doxygen 1.9.7)

### DIFF
--- a/breathe/finder/compound.py
+++ b/breathe/finder/compound.py
@@ -1,5 +1,13 @@
 from breathe.finder import ItemFinder, stack
-from breathe.renderer.filter import Filter
+from breathe.parser.compound import compounddefTypeSub
+from breathe.renderer.filter import Filter, FilterFactory
+from breathe.parser import DoxygenCompoundParser
+
+from pprint import pprint
+
+from sphinx.application import Sphinx
+
+from typing import Any, List
 
 
 class DoxygenTypeSubItemFinder(ItemFinder):
@@ -29,6 +37,12 @@ class CompoundDefTypeSubItemFinder(ItemFinder):
 
 
 class SectionDefTypeSubItemFinder(ItemFinder):
+    def __init__(self, app: Sphinx, compound_parser: DoxygenCompoundParser, *args):
+        super().__init__(*args)
+
+        self.filter_factory = FilterFactory(app)
+        self.compound_parser = compound_parser
+
     def filter_(self, ancestors, filter_: Filter, matches) -> None:
         """Find nodes which match the filter. Doesn't test this node, only its children"""
 
@@ -39,6 +53,30 @@ class SectionDefTypeSubItemFinder(ItemFinder):
         for memberdef in self.data_object.memberdef:
             finder = self.item_finder_factory.create_finder(memberdef)
             finder.filter_(node_stack, filter_, matches)
+
+        # Descend to member children (Doxygen 1.9.7 or newer)
+        members = self.data_object.get_member()
+        # TODO: find a more precise type for the Doxygen nodes
+        member_matches: List[Any] = []
+        for member in members:
+            member_finder = self.item_finder_factory.create_finder(member)
+            member_finder.filter_(node_stack, filter_, member_matches)
+
+        # If there are members in this sectiondef that match the criteria
+        # then load up the file for the group they're in and get the member data objects
+        if member_matches:
+            matched_member_ids = (member.id for stack in matches for member in stack)
+            member_refid = member_matches[0][0].refid
+            filename = member_refid.rsplit('_', 1)[0]
+            file_data = self.compound_parser.parse(filename)
+            finder = self.item_finder_factory.create_finder(file_data)
+            for member_stack in member_matches:
+                member = member_stack[0]
+                if member.refid not in matched_member_ids:
+                    ref_filter = self.filter_factory.create_id_filter(
+                        "memberdef", member.refid
+                    )
+                    finder.filter_(node_stack, ref_filter, matches)
 
 
 class MemberDefTypeSubItemFinder(ItemFinder):

--- a/breathe/finder/compound.py
+++ b/breathe/finder/compound.py
@@ -3,8 +3,6 @@ from breathe.parser.compound import compounddefTypeSub
 from breathe.renderer.filter import Filter, FilterFactory
 from breathe.parser import DoxygenCompoundParser
 
-from pprint import pprint
-
 from sphinx.application import Sphinx
 
 from typing import Any, List

--- a/breathe/finder/factory.py
+++ b/breathe/finder/factory.py
@@ -20,6 +20,16 @@ class _CreateCompoundTypeSubFinder:
         return indexfinder.CompoundTypeSubItemFinder(self.app, compound_parser, project_info, *args)
 
 
+class _CreateSectionDefTypeSubItemFinder:
+    def __init__(self, app: Sphinx, parser_factory: DoxygenParserFactory):
+        self.app = app
+        self.parser_factory = parser_factory
+
+    def __call__(self, project_info: ProjectInfo, *args):
+        compound_parser = self.parser_factory.create_compound_parser(project_info)
+        return compoundfinder.SectionDefTypeSubItemFinder(self.app, compound_parser, project_info, *args)
+
+
 class DoxygenItemFinderFactory:
     def __init__(self, finders: Dict[str, Type[ItemFinder]], project_info: ProjectInfo):
         self.finders = finders
@@ -65,7 +75,7 @@ class FinderFactory:
             "member": indexfinder.MemberTypeSubItemFinder,
             "doxygendef": compoundfinder.DoxygenTypeSubItemFinder,
             "compounddef": compoundfinder.CompoundDefTypeSubItemFinder,
-            "sectiondef": compoundfinder.SectionDefTypeSubItemFinder,
+            "sectiondef": _CreateSectionDefTypeSubItemFinder(self.app, self.parser_factory),  # type: ignore
             "memberdef": compoundfinder.MemberDefTypeSubItemFinder,
             "ref": compoundfinder.RefTypeSubItemFinder,
         }

--- a/breathe/finder/index.py
+++ b/breathe/finder/index.py
@@ -47,22 +47,18 @@ class CompoundTypeSubItemFinder(ItemFinder):
             member_finder = self.item_finder_factory.create_finder(member)
             member_finder.filter_(node_stack, filter_, member_matches)
 
+        file_data = self.compound_parser.parse(self.data_object.refid)
+        finder = self.item_finder_factory.create_finder(file_data)
+
         # If there are members in this compound that match the criteria
         # then load up the file for this compound and get the member data objects
-        if member_matches:
-            file_data = self.compound_parser.parse(self.data_object.refid)
-            finder = self.item_finder_factory.create_finder(file_data)
-
-            for member_stack in member_matches:
-                ref_filter = self.filter_factory.create_id_filter(
-                    "memberdef", member_stack[0].refid
-                )
-                finder.filter_(node_stack, ref_filter, matches)
-        else:
-            # Read in the xml file referenced by the compound and descend into that as well
-            file_data = self.compound_parser.parse(self.data_object.refid)
-            finder = self.item_finder_factory.create_finder(file_data)
-            finder.filter_(node_stack, filter_, matches)
+        for member_stack in member_matches:
+            ref_filter = self.filter_factory.create_id_filter(
+                "memberdef", member_stack[0].refid
+            )
+            finder.filter_(node_stack, ref_filter, matches)
+        # Read in the xml file referenced by the compound and descend into that as well
+        finder.filter_(node_stack, filter_, matches)
 
 
 class MemberTypeSubItemFinder(ItemFinder):

--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -140,8 +140,8 @@ class sectiondefTypeSub(supermod.sectiondefType):
 
     node_type = "sectiondef"
 
-    def __init__(self, kind=None, header='', description=None, memberdef=None):
-        supermod.sectiondefType.__init__(self, kind, header, description, memberdef)
+    def __init__(self, kind=None, header='', description=None, memberdef=None, member=None):
+        supermod.sectiondefType.__init__(self, kind, header, description, memberdef, member)
 
 
 supermod.sectiondefType.subclass = sectiondefTypeSub
@@ -235,6 +235,16 @@ class memberdefTypeSub(supermod.memberdefType):
 
 supermod.memberdefType.subclass = memberdefTypeSub
 # end class memberdefTypeSub
+
+
+class MemberTypeSub(supermod.MemberType):
+
+    node_type = "member"
+
+    def __init__(self, kind=None, refid=None, name=''):
+        supermod.MemberType.__init__(self, kind, refid, name)
+supermod.MemberType.subclass = MemberTypeSub
+# end class MemberTypeSub
 
 
 class descriptionTypeSub(supermod.descriptionType):

--- a/breathe/parser/compoundsuper.py
+++ b/breathe/parser/compoundsuper.py
@@ -513,6 +513,48 @@ class compounddefType(GeneratedsSuper):
 # end class compounddefType
 
 
+class MemberType(GeneratedsSuper):
+    subclass = None
+    superclass = None
+    def __init__(self, kind=None, refid=None, name=None):
+        self.kind = kind
+        self.refid = refid
+        self.name = name
+    def factory(*args_, **kwargs_):
+        if MemberType.subclass:
+            return MemberType.subclass(*args_, **kwargs_)
+        else:
+            return MemberType(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def get_kind(self): return self.kind
+    def set_kind(self, kind): self.kind = kind
+    def get_refid(self): return self.refid
+    def set_refid(self, refid): self.refid = refid
+    def hasContent_(self):
+        return self.name is not None
+    def build(self, node_):
+        attrs = node_.attributes
+        self.buildAttributes(attrs)
+        for child_ in node_.childNodes:
+            nodeName_ = child_.nodeName.split(':')[-1]
+            self.buildChildren(child_, nodeName_)
+    def buildAttributes(self, attrs):
+        if attrs.get('kind'):
+            self.kind = attrs.get('kind').value
+        if attrs.get('refid'):
+            self.refid = attrs.get('refid').value
+    def buildChildren(self, child_, nodeName_):
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'name':
+            name_ = ''
+            for text__content_ in child_.childNodes:
+                name_ += text__content_.nodeValue
+            self.name = name_
+# end class MemberType
+
+
 class listofallmembersType(GeneratedsSuper):
     subclass = None
     superclass = None
@@ -989,7 +1031,7 @@ class refTextType(GeneratedsSuper):
 class sectiondefType(GeneratedsSuper):
     subclass = None
     superclass = None
-    def __init__(self, kind=None, header=None, description=None, memberdef=None):
+    def __init__(self, kind=None, header=None, description=None, memberdef=None, member=None):
         self.kind = kind
         self.header = header
         self.description = description
@@ -997,6 +1039,10 @@ class sectiondefType(GeneratedsSuper):
             self.memberdef = []
         else:
             self.memberdef = memberdef
+        if member is None:
+            self.member = []
+        else:
+            self.member = member
     def factory(*args_, **kwargs_):
         if sectiondefType.subclass:
             return sectiondefType.subclass(*args_, **kwargs_)
@@ -1011,6 +1057,10 @@ class sectiondefType(GeneratedsSuper):
     def set_memberdef(self, memberdef): self.memberdef = memberdef
     def add_memberdef(self, value): self.memberdef.append(value)
     def insert_memberdef(self, index, value): self.memberdef[index] = value
+    def get_member(self): return self.member
+    def set_member(self, member): self.member = member
+    def add_member(self, value): self.member.append(value)
+    def insert_member(self, index, value): self.member[index] = value
     def get_kind(self): return self.kind
     def set_kind(self, kind): self.kind = kind
     def hasContent_(self):

--- a/breathe/parser/compoundsuper.py
+++ b/breathe/parser/compoundsuper.py
@@ -1082,22 +1082,24 @@ class sectiondefType(GeneratedsSuper):
         if attrs.get('kind'):
             self.kind = attrs.get('kind').value
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and \
-            nodeName_ == 'header':
-            header_ = ''
-            for text__content_ in child_.childNodes:
-                header_ += text__content_.nodeValue
-            self.header = header_
-        elif child_.nodeType == Node.ELEMENT_NODE and \
-            nodeName_ == 'description':
-            obj_ = descriptionType.factory()
-            obj_.build(child_)
-            self.set_description(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and \
-            nodeName_ == 'memberdef':
-            obj_ = memberdefType.factory()
-            obj_.build(child_)
-            self.memberdef.append(obj_)
+        if child_.nodeType == Node.ELEMENT_NODE:
+            if nodeName_ == 'header':
+                header_ = ''
+                for text__content_ in child_.childNodes:
+                    header_ += text__content_.nodeValue
+                self.header = header_
+            elif nodeName_ == 'description':
+                obj_ = descriptionType.factory()
+                obj_.build(child_)
+                self.set_description(obj_)
+            elif nodeName_ == 'memberdef':
+                obj_ = memberdefType.factory()
+                obj_.build(child_)
+                self.memberdef.append(obj_)
+            elif nodeName_ == 'member':
+                obj_ = MemberType.factory()
+                obj_.build(child_)
+                self.member.append(obj_)
 # end class sectiondefType
 
 

--- a/breathe/renderer/filter.py
+++ b/breathe/renderer/filter.py
@@ -735,7 +735,7 @@ class FilterFactory:
 
     def _create_public_members_filter(self, options: Dict[str, Any]) -> Filter:
         node = Node()
-        node_is_memberdef = node.node_type == "memberdef"
+        node_is_memberdef = (node.node_type == "memberdef") | (node.node_type == "member")
         node_is_public = node.prot == "public"
 
         parent = Parent()
@@ -771,9 +771,8 @@ class FilterFactory:
         self, prot: str, option_name: str, options: Dict[str, Any]
     ) -> Filter:
         """'prot' is the doxygen xml term for 'public', 'protected' and 'private' categories."""
-
         node = Node()
-        node_is_memberdef = node.node_type == "memberdef"
+        node_is_memberdef = (node.node_type == "memberdef") | (node.node_type == "member")
         node_is_public = node.prot == prot
 
         parent = Parent()
@@ -790,7 +789,7 @@ class FilterFactory:
 
     def _create_undoc_members_filter(self, options: Dict[str, Any]) -> Filter:
         node = Node()
-        node_is_memberdef = node.node_type == "memberdef"
+        node_is_memberdef = (node.node_type == "memberdef") | (node.node_type == "member")
 
         node_has_description = (
             node.briefdescription.has_content() | node.detaileddescription.has_content()
@@ -940,7 +939,7 @@ class FilterFactory:
         node = Node()
 
         # Filter for public memberdefs
-        node_is_memberdef = node.node_type == "memberdef"
+        node_is_memberdef = (node.node_type == "memberdef") | (node.node_type == "member")
         node_is_public = node.prot == "public"
 
         public_members = node_is_memberdef & node_is_public
@@ -1022,12 +1021,13 @@ class FilterFactory:
                 self.app.config.breathe_implementation_filename_extensions
             )
             parent_is_compound = parent.node_type == "compound"
+            parent_is_sectiondef = parent.node_type == "sectiondef"
             parent_is_file = (parent.kind == "file") & (~is_implementation_file)
             parent_is_not_file = parent.kind != "file"
 
             return (parent_is_compound & parent_is_file & node_matches) | (
-                parent_is_compound & parent_is_not_file & node_matches
-            )
+                parent_is_compound & parent_is_not_file & node_matches) | (
+                parent_is_sectiondef & parent_is_not_file & node_matches)
 
     def create_function_and_all_friend_finder_filter(self, namespace: str, name: str) -> Filter:
         parent = Parent()


### PR DESCRIPTION
Needed to support XML output generated by Doxygen 1.9.7, which no longer contains duplicate member definitions (`memberdef`). The XML of the source file now contains a member reference (`member`) and only the XML of the group contains the member definition.

I tested these change on large, internal projects that use Doxygen groups and the `doxygenfunction` directive. I did not do any additional testing and am not confident that all of the changes I made are strictly necessary.

Closes #923