### PR TITLE
Resolve full title for doxygenpage and doxygengroup and allow for omitting the title all together

### DIFF
--- a/breathe/directives/content_block.py
+++ b/breathe/directives/content_block.py
@@ -106,7 +106,10 @@ class DoxygenNamespaceDirective(_DoxygenContentBlockDirective):
 class DoxygenGroupDirective(_DoxygenContentBlockDirective):
     kind = "group"
     option_spec = _DoxygenContentBlockDirective.option_spec.copy()
-    option_spec.update({"inner": flag})
+    option_spec.update({
+      "inner": flag,
+      "no-title": flag
+    })
 
 
 class DoxygenPageDirective(_DoxygenContentBlockDirective):
@@ -115,4 +118,5 @@ class DoxygenPageDirective(_DoxygenContentBlockDirective):
         "path": unchanged_required,
         "project": unchanged_required,
         "content-only": flag,
+        "no-title": flag,
     }

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1238,10 +1238,11 @@ class SphinxRenderer:
                 # Set up the title
 
                 if kind in ["group", "page"] and file_data.compounddef and file_data.compounddef.title:
-                    full_title = " ".join([i.getValue() for i in file_data.compounddef.title.content_])
-                    title_signode.append(nodes.emphasis(text=kind))
-                    title_signode.append(nodes.Text(" "))
-                    title_signode.append(addnodes.desc_name(text=full_title))
+                    if "no-title" not in options:
+                        full_title = " ".join([i.getValue() for i in file_data.compounddef.title.content_])
+                        title_signode.append(nodes.emphasis(text=kind))
+                        title_signode.append(nodes.Text(" "))
+                        title_signode.append(addnodes.desc_name(text=full_title))
                 else:
                     title_signode.append(nodes.emphasis(text=kind))
                     title_signode.append(nodes.Text(" "))

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1236,9 +1236,16 @@ class SphinxRenderer:
                 title_signode.extend(targets)
 
                 # Set up the title
-                title_signode.append(nodes.emphasis(text=kind))
-                title_signode.append(nodes.Text(" "))
-                title_signode.append(addnodes.desc_name(text=name))
+
+                if kind in ["group", "page"] and file_data.compounddef and file_data.compounddef.title:
+                    full_title = " ".join([i.getValue() for i in file_data.compounddef.title.content_])
+                    title_signode.append(nodes.emphasis(text=kind))
+                    title_signode.append(nodes.Text(" "))
+                    title_signode.append(addnodes.desc_name(text=full_title))
+                else:
+                    title_signode.append(nodes.emphasis(text=kind))
+                    title_signode.append(nodes.Text(" "))
+                    title_signode.append(addnodes.desc_name(text=name))
 
                 rst_node.append(title_signode)
 


### PR DESCRIPTION
Currently, the `doxygengroup` or `doxygenpage` directives will render a line like
```
page page_id
```
or
```
group group_id
```
before the actual description and content, where `page_id` and `group_id` are the ids as specified in the corresponding doxygen commands, e.g.:
```
@defgroup   group_id   This is my group of functions
@page page_id  This is my page with some nice content
```
What one would rather have rendered in the .rst output is the *full* titles, not just the ids.
This set of patches addresses that problem by resolving the full title of the `group` or `page` if it is available in the doxygen xml ouput.

Moreover, the second patch introduces a new option for the `doxygenpage` and `doxygengroup` directives: `no-title`.
The purpose of this flag is to allow for leaving out just the title of a page or group, which is useful if the actual title is included in the .rst document that calls the directive. For instance:
```
My API group
------------
Below are all symbols related to this group of functions

.. doxygengroup:: group_id
    :no-title:
```
would render such that the description and content smoothly follow the text in the .rst file without any doxygen-specific title for `group_id`. Note, that when the group contains additional [doxygen `@name`](https://www.doxygen.nl/manual/commands.html#cmdname) commands (member group names) that further sub-group the members of a group, they are still shown. So sub-grouping/member groups are still working as before.

I introduced the `no-title` option since when using `content-only` all sub-group names where lost together with the actual group/page title. But I wanted to keep the sub-group names while still leaving out the title.

I believe this option and the expansion to the full group/page title may be useful for others as well.