### PR TITLE
Fix README: Bump Python to >= 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ branch.
 Requirements
 ------------
 
-Breathe requires Python 3.6+, Sphinx 4.0+ and Doxygen 1.8+.
+Breathe requires Python 3.7+, Sphinx 4.0+ and Doxygen 1.8+.
 
 Mailing List Archives
 ---------------------


### PR DESCRIPTION
Just README update, bump already done in #866

Fixes #951