### PR TITLE
Add python version requirement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,6 @@ setup(
             "breathe-apidoc = breathe.apidoc:main",
         ],
     },
+    python_requires='>=3.7',
     install_requires=requires,
 )


### PR DESCRIPTION
`pip` can use the information for dependency management.

Fixes #950