### PR TITLE
Insert signature name for use with Sphinx ToC

### DIFF
--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -686,6 +686,14 @@ class SphinxRenderer:
         assert len(desc) >= 1
         sig = desc[0]
         assert isinstance(sig, addnodes.desc_signature)
+
+        # Insert the member name for use in Sphinx-generated table of contents.
+        member_name = node.get_name()
+        if obj_type == "function":
+            member_name += "()"
+        sig.attributes["_toc_name"] = member_name
+        sig.attributes["_toc_parts"] = member_name
+
         # if may or may not be a multiline signature
         isMultiline = sig.get("is_multiline", False)
         declarator: Optional[Declarator] = None


### PR DESCRIPTION
This allows Sphinx to generate an entry in the table of content for each member, using the basic API name (not the full API signature). Here's an example output from a C library, using the sphinx theme:

<img width="272" alt="Screenshot 2023-10-24 at 2 31 36 PM" src="https://github.com/breathe-doc/breathe/assets/1672461/63a88086-8072-4f90-bfa0-0c0b92ece7f9">

NOTE: I have not been able to successfully run the Breathe tests. Running `make dev-test` always fails, even without this change.

Resolves https://github.com/breathe-doc/breathe/issues/958