### PR TITLE
Add option to change subclasses output

### DIFF
--- a/breathe/directives/class_like.py
+++ b/breathe/directives/class_like.py
@@ -5,7 +5,7 @@ from breathe.renderer.mask import NullMaskFactory
 from breathe.renderer.target import create_target_handler
 
 from docutils.nodes import Node
-from docutils.parsers.rst.directives import unchanged_required, unchanged, flag
+from docutils.parsers.rst.directives import unchanged_required, unchanged, flag, choice
 
 from typing import Any, List
 
@@ -27,6 +27,7 @@ class _DoxygenClassLikeDirective(BaseDirective):
         "outline": flag,
         "no-link": flag,
         "allow-dot-graphs": flag,
+        "subclasses": lambda arg: choice(arg, ["none", "list", "paragraph"]),
     }
     has_content = False
 

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1335,13 +1335,26 @@ class SphinxRenderer:
                 if node is None:
                     return []
                 output = self.render_iterable(node)
-                if not output:
+                subclasses = options.get("subclasses", "paragraph")
+                if not output or subclasses == "none":
                     return []
-                return [
-                    nodes.paragraph(
-                        "", "", nodes.Text("Subclassed by "), *intersperse(output, nodes.Text(", "))
-                    )
-                ]
+                if subclasses == "paragraph":
+                    return [
+                        nodes.paragraph(
+                            "", "", nodes.Text("Subclassed by "), *intersperse(output, nodes.Text(", "))
+                        )
+                    ]
+                if subclasses == "list":
+                    body = nodes.bullet_list()
+                    for o in output:
+                        body.append(nodes.list_item("", nodes.paragraph("", "", o)))
+                    return [
+                        nodes.paragraph(
+                            "", "", nodes.Text("Subclassed by:")
+                        ),
+                        body
+                    ]
+                raise RuntimeError(f'Unrecognized "subclasses" option: {options["inheritance"]}')
 
             addnode(
                 "derivedcompoundref", lambda: render_derivedcompoundref(node.derivedcompoundref)


### PR DESCRIPTION
This PR adds an option to change how the inheritance information is printed. The option is `:subclasses:` and possible values are `none, list, paragraph`. The `paragraph` option corresponds to how it is currently done, `list` will create a bullet list with each subclass as an individual item, and `none` will skip the subclasses (helpful in combination with the exhale project). If the option is not provided, then the `paragraph` value is used.

Todo:

- [ ] add example
- [ ] update documentation