### PR TITLE
Remove duplicated virtual functions from using-declarations

### DIFF
--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -143,6 +143,19 @@ class sectiondefTypeSub(supermod.sectiondefType):
     def __init__(self, kind=None, header='', description=None, memberdef=None):
         supermod.sectiondefType.__init__(self, kind, header, description, memberdef)
 
+    def build(self, node_):
+        super().build(node_)
+
+        to_be_removed = []
+        for index, member1 in enumerate(self.memberdef[:-1]):
+            refids = [base.refid for base in member1.reimplements]
+            for member2 in self.memberdef[index + 1:]:
+                member2_refids = [base.refid for base in member2.reimplements]
+                if any(refid in member2_refids for refid in refids):
+                    to_be_removed.append(member2)
+
+        for member in to_be_removed:
+            self.memberdef.remove(member)
 
 supermod.sectiondefType.subclass = sectiondefTypeSub
 # end class sectiondefTypeSub


### PR DESCRIPTION
```cpp
struct Base {
  /// Zero arg impl
  virtual int foo() { return 42; };
  /// One arg impl
  virtual int foo(int x) { return x; };
};

struct Derived : public Base {
  using Base::foo;
  /// One arg override
  int foo(int x) override { return x + 1; }
};
```

This snippet generates duplicate declaration warnings in Sphinx, ultimately due to an [issue in Doxygen](https://github.com/doxygen/doxygen/issues/10588). This PR cleans up the member list by checking if multiple members reimplement the same refid, and removes duplicates.