### PR TITLE
Update `test_renderer` so that tests pass with Sphinx 7.2.

### DIFF
--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -35,7 +35,7 @@ def app(test_params, app_params, make_app, shared_result):
     """
     args, kwargs = app_params
     assert "srcdir" in kwargs
-    kwargs["srcdir"].makedirs(exist_ok=True)
+    os.makedirs(kwargs["srcdir"], exist_ok=True)
     (kwargs["srcdir"] / "conf.py").write_text("")
     app_ = make_app(*args, **kwargs)
     yield app_


### PR DESCRIPTION
Sphinx was updated in in pull request sphinx-doc/sphinx#11526 (July 2023) so that importing `sphinx.testing.path` no longer causes Sphinx application paths to belong to the class `sphinx.testing.path.path`, which has a `makedirs` method.

Instead, Sphinx application paths are now ordinary `Path` objects which lack this method, so we use `os.makedirs` instead. This is backwards compatible as `sphinx.testing.path.path` objects are pathlike and so accepted by `os.makedirs`.

* Fixes issue #975.