### PR TITLE
Avoid `RemovedInSphinx80Warning` in path-manipulation code.

### DIFF
--- a/breathe/project.py
+++ b/breathe/project.py
@@ -110,10 +110,9 @@ class ProjectInfoFactory:
         self.app = app
         # note: don't access self.app.config now, as we are instantiated at setup-time.
 
-        # Assume general build directory is the doctree directory without the last component.
-        # We strip off any trailing slashes so that dirname correctly drops the last part.
+        # Assume general build directory is the parent of the doctree directory.
         # This can be overridden with the breathe_build_directory config variable
-        self._default_build_dir = os.path.dirname(app.doctreedir.rstrip(os.sep))
+        self._default_build_dir = os.path.dirname(os.path.normpath(app.doctreedir))
         self.project_count = 0
         self.project_info_store: Dict[str, ProjectInfo] = {}
         self.project_info_for_auto_store: Dict[str, AutoProjectInfo] = {}

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -2402,12 +2402,9 @@ class SphinxRenderer:
             # Use self.project_info.project_path as the XML_OUTPUT path, and
             # make it absolute with consideration to the conf.py path
             project_path = self.project_info.project_path()
-            if os.path.isabs(project_path):
-                dot_file_path = os.path.abspath(project_path + os.sep + dot_file_path)
-            else:
-                dot_file_path = os.path.abspath(
-                    self.app.confdir + os.sep + project_path + os.sep + dot_file_path
-                )
+            dot_file_path = os.path.abspath(
+                os.path.join(self.app.confdir, project_path, dot_file_path)
+            )
         try:
             with open(dot_file_path, encoding="utf-8") as fp:
                 dotcode = fp.read()


### PR DESCRIPTION
In recent versions of Sphinx, code that treats Sphinx application paths such as `Sphinx.confdir` and `Sphinx.doctreedir` as strings emits the warning "Sphinx 8 will drop support for representing paths as strings".

This commit updates path-manipulation code to use functions in the `os.path` module, which accept path-like objects as well as strings.

* Fixes issue #974.

Note that you will need pull request #976 in order for tests to pass, due to issue #975.