### PR TITLE
Allow noindex option in addition to no-link

### DIFF
--- a/breathe/directives/class_like.py
+++ b/breathe/directives/class_like.py
@@ -26,6 +26,7 @@ class _DoxygenClassLikeDirective(BaseDirective):
         "show": unchanged_required,
         "outline": flag,
         "no-link": flag,
+        "noindex": flag,
         "allow-dot-graphs": flag,
     }
     has_content = False

--- a/breathe/directives/item.py
+++ b/breathe/directives/item.py
@@ -20,6 +20,7 @@ class _DoxygenBaseItemDirective(BaseDirective):
         "project": unchanged_required,
         "outline": flag,
         "no-link": flag,
+        "noindex": flag,
     }
     has_content = False
 


### PR DESCRIPTION
The Sphinx renderer maps the "no-link" option to "noindex" but a warning is generated since "noindex" is not in option_specs.

Add "noindex" where "no-link" is allowed.