### PR TITLE
Remove outdated list of supported targets from documentation

### DIFF
--- a/documentation/source/domains.rst
+++ b/documentation/source/domains.rst
@@ -6,12 +6,6 @@ Breathe has some limited support for Sphinx domains. It tries to output targets
 that the Sphinx domain references expect. This should allow you to use Sphinx
 domain roles like ``:c:func:`foo``` to link to output from Breathe.
 
-The following targets are supported:
-
-* C & C++ functions
-* C++ classes
-
-
 Class Example
 -------------
 


### PR DESCRIPTION
Lots of targets are supported by having a look at the generated objects.inv and this files names already quite a few of them in the examples.

It's best just to not mention things in such an explicit list which is probably outdated fairly quickly.