### PR TITLE
feat(ci): Add python 3.13 and Sphinx 8.1

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,14 +35,22 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
         sphinx-version:
           - '6.2'
-          - '7.0'
-          - '7.1'
-          - '7.2'
-          - '7.3'
-          - '7.4'
+          - '7.2' # Ubuntu 24.04
+          - '7.4' # Ubuntu 24.10
           - '8.0'
+          - '8.1' # Ubuntu 25.04
+        exclude:
+          - python-version: '3.9'
+            sphinx-version: '8.0'
+          - python-version: '3.9'
+            sphinx-version: '8.1'
+          - python-version: '3.12'
+            sphinx-version: '6.2'
+          - python-version: '3.13'
+            sphinx-version: '6.2'
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
### Changes

- Add python 3.13 and Sphinx 8.1
- Remove minor versions from old sphinx 7.x branch which are not used by Ubuntu.
- Exclude unsupported python and sphinx versions.

### Reason

A lot of unnecessary tests increase time and resource consumption. 25 tests instead of 40.