### PR TITLE
Fix test suite under Sphinx 7.4+

### DIFF
--- a/breathe/file_state_cache.py
+++ b/breathe/file_state_cache.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from sphinx.application import Sphinx

--- a/breathe/process.py
+++ b/breathe/process.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from breathe.project import AutoProjectInfo, ProjectInfoFactory

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -35,7 +35,7 @@ def app(test_params, app_params, make_app, shared_result):
     args, kwargs = app_params
     assert "srcdir" in kwargs
     os.makedirs(kwargs["srcdir"], exist_ok=True)
-    (kwargs["srcdir"] / "conf.py").write_text("")
+    (kwargs["srcdir"] / "conf.py").write_text("", encoding="ascii")
     app_ = make_app(*args, **kwargs)
     yield app_
 
@@ -547,7 +547,7 @@ def get_matches(datafile):
     from xml.dom import minidom
 
     argsstrings = []
-    with open(os.path.join(os.path.dirname(__file__), "data", datafile)) as fid:
+    with open(os.path.join(os.path.dirname(__file__), "data", datafile), encoding="utf-8") as fid:
         xml = fid.read()
     doc = minidom.parseString(xml)
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -167,13 +167,14 @@ class MockMaskFactory:
 
 class MockContext:
     def __init__(self, app, node_stack, domain=None, options=[]):
+        from docutils.statemachine import StringList
         self.domain = domain
         self.node_stack = node_stack
         self.directive_args = [
             None,  # name
             None,  # arguments
             options,  # options
-            None,  # content
+            StringList([], items=[]),  # content
             None,  # lineno
             None,  # content_offset
             None,  # block_text

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -124,7 +124,7 @@ class MockState:
         env.temp_data["docname"] = "mock-doc"
         env.temp_data["breathe_project_info_factory"] = ProjectInfoFactory(app)
         env.temp_data["breathe_parser_factory"] = DoxygenParserFactory(app)
-        settings = frontend.OptionParser(components=(parsers.rst.Parser,)).get_default_values()
+        settings = frontend.get_default_settings(parsers.rst.Parser)
         settings.env = env
         self.document = utils.new_document("", settings)
 


### PR DESCRIPTION
The source of this issue is https://github.com/sphinx-doc/sphinx/pull/12492, which changed how directive content gets parsed. Previously, it went through `SphinxDirective.state.nested_parse()` which `MockState` implements as a no-op, so `content` was never used.

Closes #987.