### PR TITLE
Fix test failure with latest Sphinx master

### DIFF
--- a/breathe/directives/function.py
+++ b/breathe/directives/function.py
@@ -166,7 +166,7 @@ class DoxygenFunctionDirective(BaseDirective):
         parser = cpp.DefinitionParser(
             function_description, location=self.get_source_info(), config=self.config
         )
-        paramQual = parser._parse_parameters_and_qualifiers(paramMode="function")
+        paramQual = parser._parse_parameters_and_qualifiers("function")
         # strip everything that doesn't contribute to overloading
 
         def stripParamQual(paramQual):


### PR DESCRIPTION
This parameter name was changed from camelCase to snake_case in https://github.com/sphinx-doc/sphinx/commit/a48e1e28dbfb00f6e8a4918d5fc72fbc6975d7fa.