### PR TITLE
Fix errors in template specialization with qualified arguments

### DIFF
--- a/breathe/renderer/filter.py
+++ b/breathe/renderer/filter.py
@@ -475,7 +475,12 @@ class NamespaceFilter(Filter):
         name = self.name_accessor(node_stack)
 
         try:
-            namespace, name = name.rsplit("::", 1)
+            # strip out any template arguments before splitting on '::', to
+            # avoid errors if a template specialization has qualified arguments
+            # (see examples/specific/cpp_ns_template_specialization)
+            cleaned_name, sep, rest = name.partition("<")
+            namespace, name = cleaned_name.rsplit("::", 1)
+            name += sep + rest
         except ValueError:
             namespace, name = "", name
 

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1021,12 +1021,15 @@ class SphinxRenderer:
             # Defer to domains specific directive.
 
             names = self.get_qualification()
-            # TODO: this breaks if it's a template specialization
-            #       and one of the arguments contain '::'
+            # strip out any template arguments before splitting on '::', to
+            # avoid errors if a template specialization has qualified arguments
+            # (see examples/specific/cpp_ns_template_specialization)
+            cleaned_name, sep, rest = nodeDef.compoundname.partition("<")
             if self.nesting_level == 0:
-                names.extend(nodeDef.compoundname.split("::"))
+                names.extend(cleaned_name.split("::"))
             else:
-                names.append(nodeDef.compoundname.split("::")[-1])
+                names.append(cleaned_name.split("::")[-1])
+            names[-1] += sep + rest
             decls = [
                 self.create_template_prefix(nodeDef),
                 self.join_nested_name(names),

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -232,6 +232,7 @@ breathe_projects = {
     "cpp_function_lookup": "../../examples/specific/cpp_function_lookup/xml/",
     "cpp_friendclass": "../../examples/specific/cpp_friendclass/xml/",
     "cpp_inherited_members": "../../examples/specific/cpp_inherited_members/xml/",
+    "cpp_ns_template_specialization": "../../examples/specific/cpp_ns_template_specialization/xml/",
     "cpp_trailing_return_type": "../../examples/specific/cpp_trailing_return_type/xml/",
     "cpp_constexpr_hax": "../../examples/specific/cpp_constexpr_hax/xml/",
     "xrefsect": "../../examples/specific/xrefsect/xml/",

--- a/documentation/source/specific.rst
+++ b/documentation/source/specific.rst
@@ -239,6 +239,14 @@ C++ Inherited Members
 .. doxygenclass:: B
    :project: cpp_inherited_members
 
+C++ Template Specialization with Namespace
+------------------------------------------
+
+.. cpp:namespace:: @ex_specific_cpp_ns_template_specialization
+
+.. doxygenfile:: cpp_ns_template_specialization.h
+   :project: cpp_ns_template_specialization
+
 C++ Trailing Return Type
 ------------------------
 

--- a/examples/specific/Makefile
+++ b/examples/specific/Makefile
@@ -26,7 +26,7 @@ projects  = nutshell alias rst inline namespacefile array inheritance \
 			enum define interface xrefsect tables \
 			cpp_anon cpp_concept cpp_enum cpp_union cpp_function cpp_friendclass \
 			cpp_inherited_members cpp_trailing_return_type cpp_constexpr_hax \
-			cpp_function_lookup \
+			cpp_function_lookup cpp_ns_template_specialization \
 			c_file c_struct c_enum c_typedef c_macro c_union membergroups \
 			simplesect code_blocks dot_graphs
 

--- a/examples/specific/cpp_ns_template_specialization.cfg
+++ b/examples/specific/cpp_ns_template_specialization.cfg
@@ -1,0 +1,13 @@
+PROJECT_NAME     = "C++ Template Specialization with Namespace"
+OUTPUT_DIRECTORY = cpp_ns_template_specialization
+GENERATE_LATEX   = NO
+GENERATE_MAN     = NO
+GENERATE_RTF     = NO
+CASE_SENSE_NAMES = NO
+INPUT            = cpp_ns_template_specialization.h
+QUIET            = YES
+JAVADOC_AUTOBRIEF = YES
+GENERATE_HTML = NO
+GENERATE_XML = YES
+
+WARN_IF_UNDOCUMENTED = NO

--- a/examples/specific/cpp_ns_template_specialization.h
+++ b/examples/specific/cpp_ns_template_specialization.h
@@ -1,0 +1,15 @@
+namespace ns1 {
+struct Foo {
+  int value;
+};
+} // namespace ns1
+
+namespace ns2 {
+template <class U> struct Trait {
+  static constexpr bool valid = false;
+};
+
+template <> struct Trait<ns1::Foo> {
+  static constexpr bool valid = true;
+};
+} // namespace ns2


### PR DESCRIPTION
This addresses the problem mentioned in the TODO comment in `sphinxrenderer.py`, which I ran into with this piece of code: https://github.com/AMReX-Astro/Microphysics/blob/b7fa023216305edce0ea4a8cff60e6a781a69400/util/microphysics_autodiff.H#L229-L234

The change in `sphinxrenderer.py` fixes the class name being cut off inside the template argument, corresponding to this warning:
```
breathe/documentation/source/specific.rst:247: WARNING: Invalid C++ declaration: Expected end of definition. [error at 15]
  template<> Foo >
  ---------------^
```
The change in `filter.py` fixes the class being duplicated outside its namespace, corresponding to these errors and warnings:
```
breathe/documentation/source/specific.rst:3: CRITICAL: Duplicate ID: "cpp_ns_template_specializationstructns2_1_1_trait_3_01ns1_1_1_foo_01_4_1ae96d840cc2c8f12b13e15f5b66dbdf03".
breathe/documentation/source/specific.rst:3: WARNING: Duplicate explicit target name: "cpp_ns_template_specializationstructns2_1_1_trait_3_01ns1_1_1_foo_01_4_1ae96d840cc2c8f12b13e15f5b66dbdf03".
breathe/documentation/source/specific.rst:3: CRITICAL: Duplicate ID: "cpp_ns_template_specializationstructns2_1_1_trait_3_01ns1_1_1_foo_01_4".
breathe/documentation/source/specific.rst:3: WARNING: Duplicate explicit target name: "cpp_ns_template_specializationstructns2_1_1_trait_3_01ns1_1_1_foo_01_4".
```

<details><summary>Before and after screenshots</summary>
<p>

| Before | After |
|--------|--------|
| ![breathe-ns-template-spec-before](https://github.com/user-attachments/assets/1328612b-1e0f-46d0-86d0-301dadfcfd72) | ![breathe-ns-template-spec-after](https://github.com/user-attachments/assets/574010ef-f7d3-4b85-88ab-07e01ee74244) | 

</p>
</details> 
