### PR TITLE
chore: improve lint tools

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install "black==22.3.0"
+        python -m pip install ".[lint]"
     - name: Format with black
       run: black --check .
 
@@ -44,7 +44,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade "flake8>=6"
+        python -m pip install ".[lint]"
     - name: Lint with flake8
       run: flake8 breathe
 

--- a/breathe/apidoc.py
+++ b/breathe/apidoc.py
@@ -68,11 +68,7 @@ def write_file(name, text, args):
 
 def format_heading(level, text):
     """Create a heading of <level> [1, 2 or 3 supported]."""
-    underlining = [
-        "=",
-        "-",
-        "~",
-    ][
+    underlining = ["=", "-", "~"][
         level - 1
     ] * len(text)
     return "%s\n%s\n\n" % (text, underlining)

--- a/breathe/apidoc.py
+++ b/breathe/apidoc.py
@@ -68,7 +68,11 @@ def write_file(name, text, args):
 
 def format_heading(level, text):
     """Create a heading of <level> [1, 2 or 3 supported]."""
-    underlining = ["=", "-", "~",][
+    underlining = [
+        "=",
+        "-",
+        "~",
+    ][
         level - 1
     ] * len(text)
     return "%s\n%s\n\n" % (text, underlining)

--- a/breathe/directives/__init__.py
+++ b/breathe/directives/__init__.py
@@ -25,7 +25,7 @@ class _WarningHandler:
         raw_text: str,
         *,
         rendered_nodes: Optional[Sequence[nodes.Node]] = None,
-        unformatted_suffix: str = ""
+        unformatted_suffix: str = "",
     ) -> List[nodes.Node]:
         raw_text = self.format(raw_text) + unformatted_suffix
         if rendered_nodes is None:

--- a/breathe/filetypes.py
+++ b/breathe/filetypes.py
@@ -2,6 +2,7 @@
 A module to house the methods for resolving a code-blocks language based on filename
 (and extension).
 """
+
 from typing import Optional
 import os.path
 

--- a/breathe/renderer/__init__.py
+++ b/breathe/renderer/__init__.py
@@ -26,7 +26,7 @@ def format_parser_error(name, error, filename, state, lineno, do_unicode_warning
             "",
             nodes.paragraph("", "", nodes.Text(warning)),
             nodes.paragraph("", "", nodes.Text(explanation)),
-            *unicode_explanation
+            *unicode_explanation,
         ),
         state.document.reporter.warning(
             warning + explanation + unicode_explanation_text, line=lineno

--- a/examples/doxygen/pyexample.py
+++ b/examples/doxygen/pyexample.py
@@ -3,6 +3,7 @@
 #
 #  More details.
 
+
 ## Documentation for a function.
 #
 #  More details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ docs = [
     "sphinxcontrib-spelling",
 ]
 lint = [
-    "black==22.3.0",
+    "black==24.10.0",
     "flake8>=6.0",
     "mypy>=1",
     "types-docutils",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ docs = [
 ]
 lint = [
     "black==24.10.0",
-    "flake8>=6.0",
+    "flake8==7.1.1",
     "mypy>=1",
     "types-docutils",
     "types-Pygments",


### PR DESCRIPTION
### Changes

- Bump `black` to current release.
- Pin `flake8` to avoid breaks due breaking releases.
- Use lint dependencies from `pyproject.toml`.