### PR TITLE
Fix dash rendering

### DIFF
--- a/breathe/parser/compound.py
+++ b/breathe/parser/compound.py
@@ -1216,13 +1216,14 @@ class docParaTypeSub(supermod.docParaType):
             obj_ = supermod.docDotType.factory()
             obj_.build(child_)
             self.content.append(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and (
-            nodeName_ == "ndash" or nodeName_ == "mdash"
-        ):
-            # inject a emphasized dash unicode char as a placeholder/flag for rendering
-            # later. See visit_docblockquote()
+        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "ndash":
             obj_ = self.mixedclass_(
-                MixedContainer.CategoryText, MixedContainer.TypeText, "", "&#8212;"
+                MixedContainer.CategoryText, MixedContainer.TypeText, "", "--"
+            )
+            self.content.append(obj_)
+        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "mdash":
+            obj_ = self.mixedclass_(
+                MixedContainer.CategoryText, MixedContainer.TypeText, "", "---"
             )
             self.content.append(obj_)
         else:

--- a/breathe/renderer/sphinxrenderer.py
+++ b/breathe/renderer/sphinxrenderer.py
@@ -1519,12 +1519,14 @@ class SphinxRenderer:
 
     def visit_docblockquote(self, node) -> list[Node]:
         nodelist = self.render_iterable(node.para)
-        # catch block quote attributions here; the <ndash/> tag is the only identifier,
-        # and it is nested within a subsequent <para> tag
-        if nodelist and nodelist[-1].astext().startswith("&#8212;"):
-            # nodes.attribution prepends the author with an emphasized dash.
-            # replace the &#8212; placeholder and strip any leading whitespace.
-            text = nodelist[-1].astext().replace("&#8212;", "").lstrip()
+        # catch block quote attributions here
+        # Markdown doesn't seem to have attribution syntax, so we look for two or more
+        # leading hyphens followed by whitespace in the last line of the block quote.
+        regexp = r"^--+\s+"
+        if nodelist and re.match(regexp, nodelist[-1].astext()):
+            # nodes.attribution prepends the author with an emphasized dash, so we strip off
+            # leading dashes followed by whitespace.
+            text = re.sub(regexp, "", nodelist[-1].astext())
             nodelist[-1] = nodes.attribution("", text)
         return [nodes.block_quote("", classes=[], *nodelist)]
 


### PR DESCRIPTION
PR #759 replaces `ndash/` and `mdash/` tags with Unicode `&#8212;`, which is not being rendered properly:

![image](https://github.com/user-attachments/assets/c8a6b2da-9ac4-4d28-9ea2-49c357b5bf5b)

Instead, I replace `ndash/` and `mdash/` with `--` and `---`, respectively, which are rendered properly in my tests.

Here are some examples:

```
> This is a block quote with en-dash (two hyphens) attribution.
>
> -- Anonymous
```

![image](https://github.com/user-attachments/assets/6d21b967-a327-4080-8473-3d7e1040e067)

```
> This is a block quote with em-dash (three hyphens) attribution.
>
> --- Anonymous
```

![image](https://github.com/user-attachments/assets/30b1188c-85ce-4f5f-8a91-da84ac5fb248)

```
> This is a block quote with lots of hyphens in the attribution.
>
> -------------- Anonymous
```

![image](https://github.com/user-attachments/assets/419a204b-1255-41a5-948f-57dd9988d3d5)

```
> -- This is a block quote with en-dashes in the quotation --
>
> -- Anonymous
```

![image](https://github.com/user-attachments/assets/8b7df1f4-328b-45d7-8124-06250df0ee71)

```
> -- Dashes -- --- everywhere! ---
>
> -- Here -- --- too! ---
>
> -- --- --Anonymous ---
```

![image](https://github.com/user-attachments/assets/1ec813b0-9d98-40ae-803f-d0663bdabb72)

```
Text - with - hyphens

Text -- with -- endashes

Text --- with --- emdashes
```

![image](https://github.com/user-attachments/assets/f50dad47-29b1-43c6-9883-f533152f1656)
