### PR TITLE
Enable imgconverter extension to fix LaTeX documentation build

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -22,6 +22,7 @@ sys.path.append(str(PROJECT_ROOT))
 extensions = [
     "breathe",
     "sphinx.ext.graphviz",
+    "sphinx.ext.imgconverter",
     "sphinx_copybutton",
     "sphinxcontrib.spelling",
 ]


### PR DESCRIPTION
This fixes LaTeX/PDF build which was otherwise failing since 571240c71106c15c8da632e519dd4e3160df5011 with:

```
! LaTeX Error: Unknown graphics extension: .svg.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.11355 ...\sphinxpxdimen]{{BreatheFlowChart}.svg}
                                                  \hspace*{\fill}}
? 
! Emergency stop.
 ...                                              
                                                  
l.11355 ...\sphinxpxdimen]{{BreatheFlowChart}.svg}
                                                  \hspace*{\fill}}
!  ==> Fatal error occurred, no output PDF file produced!
```

Note: [sphinx.ext.imgconverter](https://www.sphinx-doc.org/en/master/usage/extensions/imgconverter.html) is a built-in Sphinx extension. There is another extension called [sphinxcontrib-svg2pdfconverter](https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter) which does not rasterize the images, but it is a third party dependency, so I did not use it. However, if you think it's better, I can update this PR.