### PR TITLE
Fix some incorrect indents in the document

### DIFF
--- a/documentation/source/codeguide.rst
+++ b/documentation/source/codeguide.rst
@@ -8,21 +8,21 @@ How It Works
 There are three main sections to Breathe: parser, finders and renderers.
 Briefly:
 
-   **parser**
-      Responsible for reading the doxygen xml output and creating objects
-      representing the data. Found in ``breathe.parser``.
-      
-   **finders**
-      Responsible for finding reference objects within the output from the
-      parser. Found in ``breathe.finder``.
+**parser**
+   Responsible for reading the doxygen xml output and creating objects
+   representing the data. Found in ``breathe.parser``.
 
-   **renderers**
-      Responsible for producing reStructuredText nodes to represent the objects
-      that the finders have found. The renderers generally descend through the
-      object hierarchies rendering the objects, their children, their children's
-      children and so on. Found in ``breathe.renderer``.
+**finders**
+   Responsible for finding reference objects within the output from the
+   parser. Found in ``breathe.finder``.
 
-The following flow chart shows how the different components of Breathe transform 
+**renderers**
+   Responsible for producing reStructuredText nodes to represent the objects
+   that the finders have found. The renderers generally descend through the
+   object hierarchies rendering the objects, their children, their children's
+   children and so on. Found in ``breathe.renderer``.
+
+The following flow chart shows how the different components of Breathe transform
 data. The shaded region indicates which components are part of Breathe.
 
 .. image:: ../assets/BreatheFlowChart.svg

--- a/documentation/source/domains.rst
+++ b/documentation/source/domains.rst
@@ -20,8 +20,8 @@ Given the following Breathe directives:
 
 Which create formatted output like:
 
-   .. doxygenclass:: TestNamespaceClasses::NamespacedClassTest
-      :path: ../../examples/specific/class/xml
+.. doxygenclass:: TestNamespaceClasses::NamespacedClassTest
+   :path: ../../examples/specific/class/xml
 
 We can refer to **NamespacedClassTest** using:
 
@@ -50,9 +50,9 @@ Given the following Breathe directive::
 
 Which create formatted output like:
 
-   .. doxygenclass:: OuterClass
-      :path: ../../examples/specific/class/xml
-      :members:
+.. doxygenclass:: OuterClass
+   :path: ../../examples/specific/class/xml
+   :members:
 
 We can refer to **OuterClass::InnerClass** using::
 
@@ -77,11 +77,11 @@ Given the following Breathe directives:
 
 Which create formatted output like:
 
-   .. doxygenfunction:: TestNamespaceClasses::NamespacedClassTest::function
-      :path: ../../examples/specific/class/xml
+.. doxygenfunction:: TestNamespaceClasses::NamespacedClassTest::function
+   :path: ../../examples/specific/class/xml
 
-   .. doxygenfunction:: frob_foos
-      :path: ../../examples/specific/alias/xml
+.. doxygenfunction:: frob_foos
+   :path: ../../examples/specific/alias/xml
 
 We can refer to **namespaceFunc** using:
 
@@ -133,15 +133,15 @@ Given the following Breathe directives:
 
 which create formatted output like:
 
-   .. doxygentypedef:: TestTypedef
-      :path: ../../examples/specific/typedef/xml
+.. doxygentypedef:: TestTypedef
+   :path: ../../examples/specific/typedef/xml
 
-   .. doxygennamespace:: TypeDefNamespace
-      :path: ../../examples/specific/typedef/xml
+.. doxygennamespace:: TypeDefNamespace
+   :path: ../../examples/specific/typedef/xml
 
-   .. doxygenclass:: TestClass
-      :path: ../../examples/specific/typedef/xml
-      :members:
+.. doxygenclass:: TestClass
+   :path: ../../examples/specific/typedef/xml
+   :members:
 
 We can refer to **TestTypedef** using:
 
@@ -180,11 +180,11 @@ Given the following Breathe directives:
 
 Which create formatted output like:
 
-   .. doxygenenumvalue:: VALUE
-      :path: ../../examples/specific/enum/xml
+.. doxygenenumvalue:: VALUE
+   :path: ../../examples/specific/enum/xml
 
-   .. doxygenenumvalue:: TestEnumNamespace::FIRST
-      :path: ../../examples/specific/enum/xml
+.. doxygenenumvalue:: TestEnumNamespace::FIRST
+   :path: ../../examples/specific/enum/xml
 
 We can refer to **VALUE** using:
 


### PR DESCRIPTION
Incorrect indents cause some texts to be misinterpreted and render incorrectly.